### PR TITLE
docs: update frontend stack to next.js

### DIFF
--- a/docs/Business Process Workflow.md
+++ b/docs/Business Process Workflow.md
@@ -9,7 +9,7 @@ This document formalises, in developer-friendly language, the **end-to-end busin
 | **Student** | Submits a single essay per task, reviews AI reports, performs inline edits after grading; may replace submission only if teacher returns it. |
 | **Teacher** | Creates tasks, defines rubrics, monitors progress, issues final grades. |
 | **Administrator** | Manages users, global settings, feature toggles, compliance. |
-| **Frontend (Vue SPA)** | Collects user input, renders dashboards, orchestrates client-side state. |
+| **Frontend (Next.js App)** | Collects user input, renders dashboards, orchestrates client-side state. |
 | **API Gateway** | Single public entry-point; enforces authN/Z, throttling and routing. |
 | **Microservices** | UMS, ESS, AES, ARS… perform domain logic (see functional-module doc). |
 | **Async Processing** | MVP: Django async views + PostgreSQL. Future: Redis + Celery for scalable queueing. |

--- a/docs/EssayCoach Platform Summary.md
+++ b/docs/EssayCoach Platform Summary.md
@@ -27,9 +27,9 @@ EssayCoach is a future-oriented intelligent education platform designed to lever
 Our technology selection adheres to "API-first," "front-end/back-end separation," and "microservices" principles, ensuring system scalability, maintainability, and cross-platform compatibility.
 
 *   **Frontend:**
-    *   **Framework:** **Vue.js (Vue 3)** - As per your decision. Its component-based architecture, rich ecosystem (e.g., Vue Router, Pinia), and excellent performance are ideal for building complex Single Page Applications (SPAs).
-    *   **UI Library:** Using Naive UI components for modern, responsive design, and a consistent user experience.
-    *   **Build Tool:** Vite - Offers an extremely fast development server and optimized bundling.
+    *   **Framework:** **Next.js 15 (React 19)** — providing hybrid static/SSR rendering, file-based routing, and strong TypeScript support for building complex applications.
+    *   **UI Library:** shadcn/ui built on Radix components and Tailwind CSS for a modern, responsive design system.
+    *   **Build Tool:** Next.js (Turbopack) - Offers a fast development server and optimized bundling.
 
 *   **Backend:**
     *   **Main Framework:** **Python (Django)** - Python is the preferred language for AI/ML. Django provides a robust, batteries-included framework with excellent ORM, admin interface, and mature ecosystem. While FastAPI offers high performance for AI services, Django's comprehensive features and stability make it ideal for the core backend architecture. We may consider adding Flask API or Node.js services in the future if we need to handle more concurrent AI API calls.

--- a/docs/EssayCoach Platform Technical Project Summary.md
+++ b/docs/EssayCoach Platform Technical Project Summary.md
@@ -16,18 +16,18 @@ We will implement a **distributed microservices architecture**, designed for hig
 *   **Cloud-Native:** Leveraging Alibaba Cloud's managed services for databases, storage, AI inferencing, and container orchestration.
 
 ### High-Level Data Flow:
-`Student Web App (Vue.js)` <--> `Alibaba Cloud CDN/OSS` <--> `Alibaba Cloud API Gateway` <--> `Core Microservices (FastAPI)` <--> `Alibaba Cloud Message Queue` <--> `AI Worker Services (FastAPI/PAI-EAS)` <--> `ApsaraDB for RDS (PostgreSQL)` / `ApsaraDB for OpenSearch (Vector Search)` / `OSS`
+`Student Web App (Next.js)` <--> `Alibaba Cloud CDN/OSS` <--> `Alibaba Cloud API Gateway` <--> `Core Microservices (FastAPI)` <--> `Alibaba Cloud Message Queue` <--> `AI Worker Services (FastAPI/PAI-EAS)` <--> `ApsaraDB for RDS (PostgreSQL)` / `ApsaraDB for OpenSearch (Vector Search)` / `OSS`
 
 ## 3. Core Technical Components & Services
 
-### 3.1 Frontend (Vue.js 3 SPA)
-*   **Framework:** Vue.js 3 — leveraging the **Celeris Web Vue template** (Composition API & Vite powered).
-*   **State Management:** Pinia for lightweight, modular global state.
-*   **Routing:** Vue Router.
-*   **UI Library:** **Naive UI** for a modern, theme-able component set.
-*   **CSS Utility:** **UnoCSS** for atomic/utility-first styling and design tokens.
+### 3.1 Frontend (Next.js Application)
+*   **Framework:** Next.js 15 with React 19 and TypeScript.
+*   **State Management:** Zustand for lightweight, modular global state.
+*   **Routing:** Next.js App Router.
+*   **UI Library:** shadcn/ui (Radix + Tailwind) for a modern, theme-able component set.
+*   **CSS Utility:** Tailwind CSS for utility-first styling and design tokens.
 *   **API Client:** Axios for HTTP requests.
-*   **Build & Deployment:** Production builds (static assets) will be deployed to **Alibaba Cloud OSS** buckets and served via **Alibaba Cloud CDN** for global low-latency access within China.
+*   **Build & Deployment:** Production builds will be deployed to **Alibaba Cloud OSS** buckets and served via **Alibaba Cloud CDN** for low-latency access within China.
 
 ### 3.2 Backend Microservices (Python / Django)
 The backend is built using **Django** with a modular app structure. While initially designed as microservices, the current implementation uses Django's built-in app structure for rapid development. Each Django app handles specific domain responsibilities, with the flexibility to extract into separate services later if needed. We use Django's ORM, admin interface, and REST framework for API development.

--- a/docs/Functional Module Design.md
+++ b/docs/Functional Module Design.md
@@ -7,7 +7,7 @@ This document decomposes the EssayCoach platform into discrete **functional modu
 ```mermaid
 graph LR
     subgraph "Client Tier"
-        Vue["Vue 3 SPA"]
+        Next["Next.js Web App"]
     end
 
     subgraph "Gateway Tier"
@@ -31,7 +31,7 @@ graph LR
         VS[("Vector Search\n(OpenSearch)")]
     end
 
-    Vue --> APIGW
+    Next --> APIGW
     APIGW -->|REST| UMS
     APIGW -->|REST| ESS
     APIGW -->|REST| ARS

--- a/docs/Navigation Bars Design.md
+++ b/docs/Navigation Bars Design.md
@@ -258,29 +258,29 @@ graph TD
 ```
 src/layouts/
 ├── header/
-│   ├── AppHeader.vue (main header component)
+│   ├── AppHeader.tsx (main header component)
 │   ├── components/
-│   │   ├── BreadcrumbNav.vue
-│   │   ├── GlobalSearch.vue
-│   │   ├── NotificationBell.vue
-│   │   └── UserDropdown.vue
+│   │   ├── BreadcrumbNav.tsx
+│   │   ├── GlobalSearch.tsx
+│   │   ├── NotificationBell.tsx
+│   │   └── UserDropdown.tsx
 ├── sidebar/
-│   ├── AppSidebar.vue (main sidebar component)
+│   ├── AppSidebar.tsx (main sidebar component)
 │   ├── components/
-│   │   ├── NavMenuItem.vue
-│   │   ├── CollapseToggle.vue
-│   │   └── QuickActions.vue
+│   │   ├── NavMenuItem.tsx
+│   │   ├── CollapseToggle.tsx
+│   │   └── QuickActions.tsx
 └── fab/
-    ├── FloatingActionButton.vue
-    ├── SpeedDial.vue
-    └── FABManager.vue (context-aware controller)
+    ├── FloatingActionButton.tsx
+    ├── SpeedDial.tsx
+    └── FABManager.tsx (context-aware controller)
 ```
 
 ### 7.2 State Management Integration
-- **Sidebar state**: `store/modules/app.ts` → `sidebarCollapsed`, `sidebarWidth`
-- **Navigation state**: `store/modules/navigation.ts` → `activeRoute`, `breadcrumbs`
-- **FAB state**: `store/modules/fab.ts` → `activeFABs`, `fabContext`
-- **Notification state**: `store/modules/notification.ts` → `unreadCount`, `alerts`
+- **Sidebar state**: `state/app.ts` → `sidebarCollapsed`, `sidebarWidth`
+- **Navigation state**: `state/navigation.ts` → `activeRoute`, `breadcrumbs`
+- **FAB state**: `state/fab.ts` → `activeFABs`, `fabContext`
+- **Notification state**: `state/notification.ts` → `unreadCount`, `alerts`
 
 ### 7.3 Accessibility Requirements
 - **ARIA labels**: All navigation elements properly labeled

--- a/docs/architecture/api-specification.md
+++ b/docs/architecture/api-specification.md
@@ -210,7 +210,7 @@ Authorization: Bearer {access_token}
 ### Request Lifecycle
 ```mermaid
 sequenceDiagram
-    participant Client as Vue.js Client
+    participant Client as Next.js Client
     participant API as Django REST API
     participant JWT as JWT Authentication
     participant Models as Django Models
@@ -309,7 +309,7 @@ flowchart TD
 ```mermaid
 graph LR
     subgraph "WebSocket Architecture"
-        Client[Vue.js Client]
+        Client[Next.js Client]
         WS1[WebSocket Connection 1]
         WS2[WebSocket Connection 2]
         Redis[Redis PubSub]

--- a/docs/architecture/nix-environment.md
+++ b/docs/architecture/nix-environment.md
@@ -141,7 +141,7 @@ python backend/manage.py test ai_feedback
 
 ### Frontend Development
 ```bash
-# Start Vite development server
+# Start Next.js development server
 cd frontend && pnpm dev
 
 # Build for production

--- a/docs/architecture/system-architecture.md
+++ b/docs/architecture/system-architecture.md
@@ -7,8 +7,8 @@ EssayCoach is built as a modern microservices-ready web application with a clear
 ```mermaid
 graph LR
     subgraph "Frontend Layer"
-        Client[Vue 3 SPA Client]
-        Vite[Vite Dev Server]
+        Client[Next.js Web App]
+        DevServer[Next.js Dev Server]
     end
     
     subgraph "Backend Layer"
@@ -26,19 +26,19 @@ graph LR
     API -- Queue Tasks --> Async
     API -- Cache Data --> Cache
     Async -- Process --> DB
-    Vite -- Hot Reload --> Client
+    DevServer -- Fast Refresh --> Client
 ```
 
 ## 🔧 Technology Stack
 
 ### Frontend Architecture
-- **Framework**: Vue 3 with Composition API
-- **Build Tool**: Vite for fast development and optimized builds
-- **UI Library**: Naive UI for consistent design system
-- **State Management**: Pinia for predictable state
-- **Routing**: Vue Router 4 with nested routes
+- **Framework**: Next.js 15 with React 19
+- **Build Tool**: Next.js (Turbopack) for fast development and optimized builds
+- **UI Library**: shadcn/ui (Radix + Tailwind) for consistent design system
+- **State Management**: Zustand for predictable state
+- **Routing**: Next.js App Router with nested routes
 - **HTTP Client**: Axios with interceptors
-- **Testing**: Vitest for unit tests, Cypress for E2E
+- **Testing**: Jest for unit tests, Playwright for E2E
 
 ### Backend Architecture
 - **Framework**: Django 4.x with Django REST Framework
@@ -152,7 +152,7 @@ graph TD
 ```mermaid
 sequenceDiagram
     participant User as Student/Teacher
-    participant Frontend as Vue.js SPA
+    participant Frontend as Next.js App
     participant API as Django REST API
     participant Auth as JWT Auth
     participant DB as PostgreSQL
@@ -211,15 +211,15 @@ graph TD
         Locust[Locust Load Testing]
     end
     subgraph "Frontend"
-        Vitest[Vitest Components]
-        Cypress[Cypress E2E]
+        Jest[Jest + Testing Library]
+        Playwright[Playwright E2E]
         PerfTest[Performance Tests]
         Lighthouse[Lighthouse Performance]
     end
     Unit --> Pytest
-    Unit --> Vitest
+    Unit --> Jest
     Integration --> APITest
-    E2E --> Cypress
+    E2E --> Playwright
     LoadTest --> Locust
     PerfTest --> Lighthouse
 ```

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -48,8 +48,8 @@ docs(api): update endpoint documentation
 
 ### TypeScript (Frontend)
 - Use strict mode
-- Prefer composition API
-- Follow Vue style guide
+- Prefer functional components and React hooks
+- Follow Next.js and React style guides
 - Run `eslint` and `prettier`
 
 ### Testing Requirements

--- a/docs/development/debugging.md
+++ b/docs/development/debugging.md
@@ -6,10 +6,10 @@ Comprehensive debugging tools and techniques for EssayCoach development.
 
 ## Frontend Debugging
 
-### Vue DevTools
-- Install Vue DevTools browser extension
-- Inspect component state and props
-- Time-travel debugging with Pinia stores
+### React DevTools
+- Install React DevTools browser extension
+- Inspect component tree, state, and props
+- Debug Zustand store updates
 - Performance profiling
 
 ### Console Debugging
@@ -18,8 +18,13 @@ Comprehensive debugging tools and techniques for EssayCoach development.
 localStorage.setItem('debug', 'essays:*')
 
 // Component debugging
-console.log('Component state:', this.$data)
-console.table('Essays array:', essays)
+import React from 'react'
+
+function Example() {
+  const state = useExampleStore()
+  console.log('Component state:', state)
+  return <div />
+}
 ```
 
 ### Network Debugging

--- a/docs/development/environment-setup.md
+++ b/docs/development/environment-setup.md
@@ -145,7 +145,7 @@ DJANGO_SECRET_KEY=dev-secret-key-change-in-production
 DEBUG=True
 
 # Frontend
-VITE_API_URL=http://localhost:8000
+NEXT_PUBLIC_API_URL=http://localhost:8000
 ```
 
 ## 🚀 Quick Start Commands
@@ -225,8 +225,8 @@ python backend/manage.py dbshell
 ```
 
 ### Frontend DevTools
-- Vue DevTools browser extension
-- Vite HMR (Hot Module Replacement)
+- React DevTools browser extension
+- Next.js Fast Refresh
 - Source maps enabled in development
 
 ## 🔧 Troubleshooting

--- a/docs/frontend/api-integration.md
+++ b/docs/frontend/api-integration.md
@@ -11,13 +11,13 @@ The frontend integrates with the Django REST API using Axios with interceptors f
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_BASE_URL,
+  baseURL: process.env.NEXT_PUBLIC_API_BASE_URL,
   timeout: 10000
 })
 
 // Request interceptor
 api.interceptors.request.use((config) => {
-  const token = useAuthStore().token
+    const token = useAuthStore.getState().token
   if (token) {
     config.headers.Authorization = `Bearer ${token}`
   }

--- a/docs/frontend/component-structure.md
+++ b/docs/frontend/component-structure.md
@@ -1,7 +1,7 @@
 # Frontend Component Structure
 
 ## Overview
-The EssayCoach frontend is built with React and follows a modular component architecture organized by feature domains.
+The EssayCoach frontend is built with Next.js (React) and follows a modular component architecture organized by feature domains.
 
 ## Directory Structure
 ```

--- a/docs/frontend/state-management.md
+++ b/docs/frontend/state-management.md
@@ -2,40 +2,56 @@
 
 ## Overview
 
-The EssayCoach frontend uses a centralized state management approach with Pinia for Vue 3 applications.
+The EssayCoach frontend uses a lightweight global state management approach with [Zustand](https://zustand-demo.pmnd.rs/) for React applications built with Next.js.
 
 ## Store Structure
 
 ### Root Store
 ```typescript
-// stores/root.ts
-export const useRootStore = defineStore('root', {
-  state: () => ({
-    user: null,
-    isAuthenticated: false,
-    theme: 'light'
-  })
-})
+// state/root.ts
+import { create } from 'zustand'
+
+interface RootState {
+  user: any
+  isAuthenticated: boolean
+  theme: 'light' | 'dark'
+  setUser: (u: any) => void
+}
+
+export const useRootStore = create<RootState>((set) => ({
+  user: null,
+  isAuthenticated: false,
+  theme: 'light',
+  setUser: (user) => set({ user, isAuthenticated: !!user })
+}))
 ```
 
 ### Essay Store
 ```typescript
-// stores/essay.ts
-export const useEssayStore = defineStore('essay', {
-  state: () => ({
-    currentEssay: null,
-    essays: [],
-    isLoading: false
-  })
-})
+// state/essay.ts
+import { create } from 'zustand'
+
+interface EssayState {
+  currentEssay: any
+  essays: any[]
+  isLoading: boolean
+  setLoading: (v: boolean) => void
+}
+
+export const useEssayStore = create<EssayState>((set) => ({
+  currentEssay: null,
+  essays: [],
+  isLoading: false,
+  setLoading: (v) => set({ isLoading: v })
+}))
 ```
 
 ## Patterns & Best Practices
 
-- Use composition API for store access
+- Access stores through React hooks
 - Implement proper TypeScript types
 - Handle async operations with proper loading states
-- Use store plugins for persistence
+- Persist critical data via middleware (e.g., localStorage)
 
 ## Development Notes
 

--- a/docs/frontend/testing.md
+++ b/docs/frontend/testing.md
@@ -2,40 +2,35 @@
 
 ## Overview
 
-Frontend testing uses Vitest for unit tests, Vue Test Utils for component testing, and Cypress for e2e tests.
+Frontend testing uses Jest for unit tests, React Testing Library for component testing, and Playwright for e2e tests.
 
 ## Unit Testing
 
 ### Component Tests
 ```typescript
-// tests/components/EssayForm.test.ts
-import { describe, it, expect } from 'vitest'
-import { mount } from '@vue/test-utils'
-import EssayForm from '@/components/EssayForm.vue'
+// tests/components/EssayForm.test.tsx
+import { render, screen } from '@testing-library/react'
+import EssayForm from '@/components/EssayForm'
 
 describe('EssayForm', () => {
   it('renders form fields', () => {
-    const wrapper = mount(EssayForm)
-    expect(wrapper.find('input[name="title"]').exists()).toBe(true)
+    render(<EssayForm />)
+    expect(screen.getByLabelText(/title/i)).toBeInTheDocument()
   })
 })
 ```
 
 ### Store Tests
 ```typescript
-// tests/stores/essay.test.ts
-import { setActivePinia, createPinia } from 'pinia'
-import { useEssayStore } from '@/stores/essay'
+// tests/state/essay.test.ts
+import { act } from 'react'
+import { useEssayStore } from '@/state/essay'
 
 describe('Essay Store', () => {
-  beforeEach(() => {
-    setActivePinia(createPinia())
-  })
-
   it('sets loading state', () => {
-    const store = useEssayStore()
-    store.setLoading(true)
-    expect(store.isLoading).toBe(true)
+    const store = useEssayStore.getState()
+    act(() => store.setLoading(true))
+    expect(useEssayStore.getState().isLoading).toBe(true)
   })
 })
 ```
@@ -54,16 +49,16 @@ afterAll(() => server.close())
 
 ## E2E Testing
 
-### Cypress Tests
+### Playwright Tests
 ```typescript
-// cypress/e2e/essay.cy.ts
-describe('Essay Creation', () => {
-  it('creates a new essay', () => {
-    cy.visit('/essays/new')
-    cy.get('[data-testid="title-input"]').type('Test Essay')
-    cy.get('[data-testid="submit-btn"]').click()
-    cy.url().should('include', '/essays/')
-  })
+// e2e/essay.spec.ts
+import { test, expect } from '@playwright/test'
+
+test('creates a new essay', async ({ page }) => {
+  await page.goto('/essays/new')
+  await page.getByTestId('title-input').fill('Test Essay')
+  await page.getByTestId('submit-btn').click()
+  await expect(page).toHaveURL(/\/essays\//)
 })
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,12 +1,12 @@
 # EssayCoach Developer Documentation
 
-Welcome to the technical documentation for EssayCoach, an AI-powered essay coaching platform built with Vue 3 frontend and Django backend.
+Welcome to the technical documentation for EssayCoach, an AI-powered essay coaching platform built with a Next.js frontend and Django backend.
 
 ## 🏗️ Architecture Overview
 
 EssayCoach is designed as a modern web application with the following architecture:
 
-- **Frontend**: Vue 3 + TypeScript + Vite with Naive UI components
+- **Frontend**: Next.js 15 + React 19 + TypeScript + Tailwind CSS with shadcn/ui components
 - **Backend**: Django REST Framework with PostgreSQL database
 - **Development Environment**: Nix flakes for reproducible builds
 - **Deployment**: Docker containers with CI/CD pipelines
@@ -22,7 +22,7 @@ nix develop
 This sets up:
 - PostgreSQL database with schema and mock data
 - Django development environment
-- Frontend development tools (Node.js, pnpm, Vite)
+- Frontend development tools (Node.js, pnpm, Next.js)
 - All documentation tools (MkDocs, material theme)
 
 ### Start Documentation Server
@@ -38,7 +38,7 @@ This documentation is organized for developers and contributors:
 - **Architecture & Design**: System design decisions and technical specifications
 - **Database Schema**: Complete database design with relationships and constraints
 - **Backend Deep Dive**: Django models, serializers, views, and async processing
-- **Frontend Architecture**: Vue 3 component structure and state management
+- **Frontend Architecture**: Next.js component structure and state management
 - **API Reference**: REST endpoints and WebSocket events
 - **Development Guide**: Setup instructions and contribution guidelines
 
@@ -53,12 +53,12 @@ This documentation is organized for developers and contributors:
 
 | Component | Technology | Purpose |
 |-----------|------------|---------|
-| Frontend | Vue 3 + TypeScript | Modern reactive UI |
+| Frontend | Next.js + React + TypeScript | Server-rendered React UI |
 | Backend | Django REST Framework | RESTful API server |
 | Database | PostgreSQL | Primary data store |
 | Dev Environment | Nix flakes | Reproducible builds |
 | Documentation | MkDocs Material | Technical documentation |
-| Testing | Pytest + Vitest | Comprehensive test suite |
+| Testing | Pytest + Jest | Comprehensive test suite |
 
 ## 🔗 Useful Links
 


### PR DESCRIPTION
## Summary
- replace Vue references with Next.js across docs and diagrams
- document Zustand-based state management and Jest/Playwright testing
- update dev environment variables and tooling for Next.js

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68b323017aa483309ed1650314c8a413